### PR TITLE
add second endpoint to route shortened url to original url

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1,13 +1,17 @@
-from flask import Flask, request
+from flask import abort, Flask, request, redirect
 
-from shortener import shorten
+from shortener import route_to_original, shorten
 
 app = Flask(__name__)
 
 
-@app.route('/')
-def hello():
-    return 'Hello, Hi There!'
+@app.route('/<url_hash>', methods=['GET'])
+def routeToUrl(url_hash):
+    original_url = route_to_original(url_hash)
+    if original_url:
+        return redirect("http://" + original_url, 301)
+    else:
+        return abort(404)
 
 
 @app.route('/shorten', methods=['POST'])

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,2 +1,3 @@
 base-62
 Flask
+validators

--- a/server/shortener.py
+++ b/server/shortener.py
@@ -5,10 +5,15 @@ TEMP_DB = {}
 
 
 def shorten(url):
-    print("original url: ", url)
     url_hash = base62.encode(abs(hash(url)))
     if url_hash not in TEMP_DB:
-        print("IN HERE")
         TEMP_DB[url_hash] = url
-    short_url = SHORTENED_URL_PREFIX + url_hash
+    short_url = url_hash
     return short_url
+
+
+def route_to_original(url_hash):
+    if url_hash not in TEMP_DB:
+        return None
+    else:
+        return TEMP_DB[url_hash]


### PR DESCRIPTION
# Context
Along with creating hashes for urls, we must also provide users with the ability to navigate to the original url via the generated hash.

# Changes
Have created a new endpoint `/<hash_value>` that queries the backend for the associated url. If no url is found then we return an `HTTP.404` status. Otherwise we return a Flask redirect `HTTP.301` status code, along with the original url.
